### PR TITLE
Add performer and tag metadata editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,12 @@
       font-family: monospace;
     }
 
+    #infoPanel input[type="text"] {
+      flex: 1;
+      padding: 4px 6px;
+      font-size: 13px;
+    }
+
     #main {
       padding: 12px;
       overflow: auto;
@@ -2548,9 +2554,12 @@
       <div class="infoRow"><span class="infoLabel">Heatmaps</span><span class="infoValue" id="infoHeatmaps">Loading…</span></div>
       <div class="infoRow"><span class="infoLabel">Subtitles</span><span class="infoValue" id="infoSubtitles">Loading…</span></div>
       <div class="infoRow"><span class="infoLabel">Face Embeddings</span><span class="infoValue" id="infoFaces">Loading…</span></div>
+      <div class="infoRow"><span class="infoLabel">Tags</span><input id="infoTags" type="text" /></div>
+      <div class="infoRow"><span class="infoLabel">Performers</span><input id="infoPerformers" type="text" /></div>
       <div id="infoMetaExtra" class="small meta-extra"></div>
       <div class="row mt-8 gap-6 wrap">
         <button class="btn" id="infoPlay">Play</button>
+        <button class="btn" id="infoSaveTags">Save Tags</button>
       </div>
     `;
       try {
@@ -2626,6 +2635,42 @@
         document.getElementById("infoVBitrate").textContent = "";
         const mf = document.getElementById("infoMetaFile");
         if (mf) mf.textContent = "❌";
+      }
+      try {
+        const tres = await fetch(
+          `/api/tags/get?path=${encodeURIComponent(file.path)}`,
+          { method: "GET" },
+        );
+        if (tres.ok) {
+          const tb = await tres.json();
+          const td = tb.data || tb;
+          const tEl = document.getElementById("infoTags");
+          const pEl = document.getElementById("infoPerformers");
+          if (tEl) tEl.value = (td.tags || []).join(", ");
+          if (pEl) pEl.value = (td.performers || []).join(", ");
+        }
+      } catch (_) {}
+      const saveTagsBtn = document.getElementById("infoSaveTags");
+      if (saveTagsBtn) {
+        saveTagsBtn.onclick = async () => {
+          const t = document
+            .getElementById("infoTags")
+            .value.split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          const p = document
+            .getElementById("infoPerformers")
+            .value.split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+          await fetch(`/api/tags/update?path=${encodeURIComponent(file.path)}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ tags: t, performers: p }),
+          });
+          file.tags = t;
+          file.performers = p;
+        };
       }
       // Update Heatmaps/Subtitles/Faces indicators dynamically
       (async () => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+httpx
 uvicorn
 pydantic
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pytest
 
 
-# Ensure v3 folder is on sys.path so `import v3.app` works when running from repo root
+# Ensure repo folder is on sys.path so `import app` works when running from repo root
 V3_DIR = Path(__file__).resolve().parent.parent
-if str(V3_DIR.parent) not in sys.path:
-    sys.path.insert(0, str(V3_DIR.parent))
+if str(V3_DIR) not in sys.path:
+    sys.path.insert(0, str(V3_DIR))
 
 
 @pytest.fixture(autouse=True)
@@ -22,7 +22,7 @@ def _env_and_cwd(tmp_path, monkeypatch):
 @pytest.fixture
 def client():
     from fastapi.testclient import TestClient  # import here to keep deps local to tests
-    from v3.app import app as fastapi_app
+    from app import app as fastapi_app
 
     with TestClient(fastapi_app) as c:
         yield c

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,4 +72,22 @@ def test_stats_counts(client, tmp_path):
     assert r.status_code == 200
     data = r.json().get('data') or {}
     assert data.get('total_files') == 2
+
+
+def test_tags_roundtrip(client, tmp_path):
+    client.post('/api/setroot', params={'root': str(tmp_path)})
+    video = tmp_path / 't.mp4'
+    video.write_bytes(b'00')
+    r_empty = client.get('/api/tags/get', params={'path': 't.mp4'})
+    assert r_empty.status_code == 200
+    data = r_empty.json().get('data') or {}
+    assert data.get('tags') == []
+    payload = {'tags': ['a', 'b', 'a'], 'performers': ['p1', 'p1']}
+    r_set = client.patch('/api/tags/update', params={'path': 't.mp4'}, json=payload)
+    assert r_set.status_code == 200
+    r_again = client.get('/api/tags/get', params={'path': 't.mp4'})
+    assert r_again.status_code == 200
+    data2 = r_again.json().get('data') or {}
+    assert data2.get('tags') == ['a', 'b']
+    assert data2.get('performers') == ['p1']
     


### PR DESCRIPTION
## Summary
- Deduplicate tags and performers when updating metadata to avoid duplicates
- Extend roundtrip test to verify unique tag and performer storage

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c24942496083309babf1b36474d83b

## Summary by Sourcery

Implement metadata editing for tags and performers with deduplication, integrate UI controls for editing, and add test coverage.

New Features:
- Add /api/tags/get and /api/tags/update endpoints for retrieving and updating file tags, performers, and descriptions
- Expose tag and performer input fields and a save button in the frontend to allow editing of tags and performers directly in the UI

Enhancements:
- Deduplicate tags and performers in the update payload to ensure unique entries

Build:
- Add httpx to requirements for HTTP testing

Tests:
- Add a round-trip test to verify GET and PATCH endpoints store and return unique tags and performers

Chores:
- Adjust test configuration to fix import path for the app module