### PR TITLE
Add plugin system and library scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 - Run: `pip install -r requirements.txt`
 - Run: `bash serve.sh`
 - Open: http://127.0.0.1:9998/
+  - Library UI: http://127.0.0.1:9998/ui/library
 
 Environment:
 - MEDIA_ROOT: absolute path of your library root (defaults to current working directory).
+- API_TOKEN: if set, API requests must include this value in an `X-API-Key` header or
+  `token` query parameter.

--- a/index.html
+++ b/index.html
@@ -760,7 +760,8 @@
 			<div class="controls">
 				<input id="rootInput" type="text" value="/Volumes/media/PornMin" placeholder="Root folder" />
 				<input id="hiddenDirPicker" type="file" style="display:none;" webkitdirectory directory />
-				<button id="setRootBtn">Set</button>
+                                <button id="setRootBtn">Set</button>
+                                <button id="scanBtn">Scan</button>
 			</div>
 			<div id="infoPanel" class="small"></div>
 			<ul id="dirs"></ul>
@@ -3438,7 +3439,8 @@
 					$('#performersInput').on('itemAdded itemRemoved', debouncedSave);
 				}
 		const rootInput = document.getElementById("rootInput");
-		const setRootBtn = document.getElementById("setRootBtn");
+           const setRootBtn = document.getElementById("setRootBtn");
+           const scanBtn = document.getElementById("scanBtn");
 		const prevBtn = document.getElementById("prevBtn");
 		const nextBtn = document.getElementById("nextBtn");
 		const pageInfo = document.getElementById("pageInfo");
@@ -5020,46 +5022,60 @@
 				});
 			}
 
-			// Wire explicit Set button to apply the root path from the input
-			if (setRootBtn) {
-				setRootBtn.onclick = async () => {
-					try {
-						const v = (rootInput && rootInput.value) ? rootInput.value.trim() : "";
-						if (!v) {
-							alert("Enter a root folder path.");
-							return;
-						}
-						status("Setting root…");
-						// Validate path first to avoid server-side errors
-						let okToSet = false;
-						try {
-							const tp = await fetch("/api/testpath?" + new URLSearchParams({ path: v }).toString(), { method: "POST" });
-							if (tp.ok) {
-								const tjson = await tp.json();
-								const tdata = tjson.data || tjson;
-								okToSet = !!(tdata && tdata.exists && tdata.is_dir);
-							}
-						} catch (_) { okToSet = false; }
-						if (!okToSet) {
-							status("");
-							alert("Path does not exist or is not a directory.");
-							return;
-						}
-						const res = await fetch("/api/setroot?" + new URLSearchParams({ root: v }).toString(), { method: "POST" });
-						if (res.ok) {
-							currentPage = 1;
-							cwd = "";
-							await load("");
-							status("OK");
-						} else {
-							status("");
-							alert("Failed to set root.");
-						}
-					} catch (_) {
-						status("");
-					}
-				};
-			}
+                        // Wire explicit Set button to apply the root path from the input
+                        if (setRootBtn) {
+                                setRootBtn.onclick = async () => {
+                                        try {
+                                                const v = (rootInput && rootInput.value) ? rootInput.value.trim() : "";
+                                                if (!v) {
+                                                        alert("Enter a root folder path.");
+                                                        return;
+                                                }
+                                                status("Setting root…");
+                                                // Validate path first to avoid server-side errors
+                                                let okToSet = false;
+                                                try {
+                                                        const tp = await fetch("/api/testpath?" + new URLSearchParams({ path: v }).toString(), { method: "POST" });
+                                                        if (tp.ok) {
+                                                                const tjson = await tp.json();
+                                                                const tdata = tjson.data || tjson;
+                                                                okToSet = !!(tdata && tdata.exists && tdata.is_dir);
+                                                        }
+                                                } catch (_) { okToSet = false; }
+                                                if (!okToSet) {
+                                                        status("");
+                                                        alert("Path does not exist or is not a directory.");
+                                                        return;
+                                                }
+                                                const res = await fetch("/api/setroot?" + new URLSearchParams({ root: v }).toString(), { method: "POST" });
+                                                if (res.ok) {
+                                                        currentPage = 1;
+                                                        cwd = "";
+                                                        await load("");
+                                                        status("OK");
+                                                } else {
+                                                        status("");
+                                                        alert("Failed to set root.");
+                                                }
+                                        } catch (_) {
+                                                status("");
+                                        }
+                                };
+                        }
+
+                        if (scanBtn) {
+                                scanBtn.onclick = async () => {
+                                        const v = (rootInput && rootInput.value) ? rootInput.value.trim() : "";
+                                        if (!v) return;
+                                        try {
+                                                await fetch("/api/scan", {
+                                                        method: "POST",
+                                                        headers: {"Content-Type": "application/json"},
+                                                        body: JSON.stringify({ path: v })
+                                                });
+                                        } catch (_) { /* ignore */ }
+                                };
+                        }
 		}
 
 		// Auto-load root folder on page load

--- a/library.html
+++ b/library.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Media Library</title>
+<style>
+body{font-family:sans-serif;margin:0;padding:1rem;}
+#results{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:1rem;margin-top:1rem;}
+.item{cursor:pointer;display:flex;flex-direction:column;align-items:center;}
+.item img{width:160px;height:90px;object-fit:cover;border-radius:4px;background:#000;}
+.item .caption{margin-top:4px;font-size:14px;text-align:center;word-break:break-word;}
+#player{width:100%;max-height:60vh;margin-top:1rem;display:none;background:#000;}
+</style>
+</head>
+<body>
+<h1>Media Library</h1>
+<div>
+<input id="search" type="text" placeholder="Search..." />
+<button id="searchBtn">Search</button>
+<button id="clearBtn">Clear</button>
+</div>
+<div id="results"></div>
+<video id="player" controls></video>
+<script>
+async function load(q=""){
+  const res=await fetch('/api/library/media'+(q?`?q=${encodeURIComponent(q)}`:''));
+  if(!res.ok) return;
+  const data=await res.json();
+  const list=data.data.files||[];
+  const results=document.getElementById('results');
+  results.innerHTML='';
+  list.forEach(f=>{
+    const div=document.createElement('div');
+    div.className='item';
+    const img=document.createElement('img');
+    img.src='/api/cover/get?path='+encodeURIComponent(f.path);
+    img.alt=f.path.split('/').pop();
+    img.onerror=()=>{img.style.display='none';};
+    div.appendChild(img);
+    const cap=document.createElement('div');
+    cap.className='caption';
+    const name=f.path.split('/').pop();
+    cap.textContent=f.metadata?.title||name;
+    div.appendChild(cap);
+    div.onclick=()=>{play(f);};
+    results.appendChild(div);
+  });
+}
+function play(file){
+  const player=document.getElementById('player');
+  player.src='/api/stream?path='+encodeURIComponent(file.path);
+  player.style.display='block';
+  player.play();
+}
+document.getElementById('searchBtn').onclick=()=>load(document.getElementById('search').value);
+document.getElementById('clearBtn').onclick=()=>{document.getElementById('search').value='';load();};
+document.getElementById('search').addEventListener('keypress',e=>{if(e.key==='Enter')load(e.target.value);});
+load();
+</script>
+</body>
+</html>

--- a/plugins/scraper.py
+++ b/plugins/scraper.py
@@ -1,0 +1,25 @@
+import httpx
+from pathlib import Path
+
+
+def register(manager):
+    manager.register("metadata", scrape)
+
+
+def scrape(path: Path, metadata: dict):
+    """Populate simple web metadata using Google suggestions."""
+    query = Path(path).stem
+    try:
+        resp = httpx.get(
+            "https://suggestqueries.google.com/complete/search",
+            params={"client": "firefox", "q": query},
+            timeout=5.0,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            suggestions = data[1] if isinstance(data, list) and len(data) > 1 else []
+            if suggestions:
+                metadata.setdefault("web", suggestions[0])
+    except Exception:
+        # Network failures shouldn't break import
+        return

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -1,0 +1,18 @@
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_api_token_required(monkeypatch):
+    monkeypatch.setenv("API_TOKEN", "secret")
+    spec = importlib.util.spec_from_file_location("app_auth", Path(__file__).resolve().parent.parent / "app.py")
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+
+    with TestClient(app_module.app) as c:
+        r = c.get("/api/library")
+        assert r.status_code == 401
+        r = c.get("/api/library", headers={"X-API-Key": "secret"})
+        assert r.status_code == 200

--- a/tests/test_library_persistence.py
+++ b/tests/test_library_persistence.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from app import import_media, STATE, _load_library
+
+
+def test_library_persisted(tmp_path):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(b"00")
+    import_media(vid)
+    lib = Path("library.json")
+    assert lib.exists()
+    # Simulate restart
+    STATE["library"] = {}
+    _load_library()
+    assert str(vid) in STATE.get("library", {})
+
+
+def test_library_query_filter(client):
+    vid = Path("one.mp4")
+    vid.write_bytes(b"00")
+    import_media(vid)
+    r = client.get("/api/library/media", params={"q": "one"})
+    assert r.status_code == 200
+    files = r.json()["data"]["files"]
+    assert any(f.get("path", "").endswith("one.mp4") for f in files)
+    r = client.get("/api/library/media", params={"q": "nomatch"})
+    assert r.status_code == 200
+    assert r.json()["data"]["files"] == []
+
+
+def test_library_filter_by_dims(client):
+    vid = Path("dim.mp4")
+    vid.write_bytes(b"00")
+    import_media(vid)
+    # Patch metadata with custom width and duration for filtering tests
+    entry = STATE["library"][str(vid)]
+    entry.setdefault("metadata", {}).setdefault("streams", [{}])[0]["width"] = 800
+    entry["metadata"].setdefault("format", {})["duration"] = "12.0"
+
+    r = client.get("/api/library/media", params={"min_width": 600, "min_duration": 10})
+    assert any(f.get("path", "").endswith("dim.mp4") for f in r.json()["data"]["files"])
+
+    r = client.get("/api/library/media", params={"min_width": 1000})
+    assert r.json()["data"]["files"] == []
+
+    r = client.get("/api/library/media", params={"min_duration": 20})
+    assert r.json()["data"]["files"] == []
+

--- a/tests/test_library_ui.py
+++ b/tests/test_library_ui.py
@@ -1,0 +1,11 @@
+from app import import_media
+
+
+def test_library_ui_served(client, tmp_path):
+    # ensure at least one file in library
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(b"00")
+    import_media(vid)
+    res = client.get("/ui/library")
+    assert res.status_code == 200
+    assert "Media Library" in res.text

--- a/tests/test_saved_searches.py
+++ b/tests/test_saved_searches.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+def write_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"00")
+    return p
+
+def test_saved_searches(client, tmp_path):
+    write_video(tmp_path, "clip.mp4")
+    r = client.post("/api/setroot", params={"root": str(tmp_path)})
+    assert r.status_code == 200
+    body = {"name": "clips", "query": {"q": "clip"}}
+    r = client.post("/api/search/saved", json=body)
+    assert r.status_code == 200
+    r = client.get("/api/search/saved")
+    assert r.status_code == 200
+    assert "clips" in r.json()["data"]["searches"]
+    r = client.get("/api/search/saved/clips")
+    assert r.status_code == 200
+    files = r.json().get("files", [])
+    assert any(f.endswith("clip.mp4") for f in files)
+    r = client.delete("/api/search/saved/clips")
+    assert r.status_code == 200
+    r = client.get("/api/search/saved")
+    assert "clips" not in r.json()["data"]["searches"]

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,40 @@
+import time
+from pathlib import Path
+
+
+def write_video(tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    p.write_bytes(b"00")
+    return p
+
+
+def _poll_job_done(client, jid: str, timeout: float = 3.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        r = client.get("/api/jobs", params={"state": "recent"})
+        assert r.status_code == 200
+        jobs = r.json()["data"]["jobs"]
+        for j in jobs:
+            if j.get("id") == jid:
+                last = j
+                if j.get("state") in ("done", "failed", "canceled"):
+                    return last
+        time.sleep(0.05)
+    return last
+
+
+def test_scan_imports_files(client, tmp_path):
+    write_video(tmp_path, "clip.mp4")
+    r = client.post("/api/setroot", params={"root": str(tmp_path)})
+    assert r.status_code == 200
+    r = client.post("/api/scan", json={"path": str(tmp_path)})
+    assert r.status_code == 200
+    jid = r.json()["data"]["job"]
+    assert isinstance(jid, str) and jid
+    j = _poll_job_done(client, jid)
+    assert j is not None and j.get("state") == "done"
+    r = client.get("/api/library/media")
+    assert r.status_code == 200
+    files = r.json()["data"].get("files", [])
+    assert any(f.get("path", "").endswith("clip.mp4") for f in files)


### PR DESCRIPTION
## Summary
- introduce lightweight plugin manager with example metadata scraper
- add `/api/scan` job that imports media into an in-memory library and exposes it via `/api/library`
- expand global search with resolution and duration filters and hook up a scan button in the UI
- persist imported library to `library.json` and expose filterable `/api/library/media` with clear option
- improve job queue visibility with immediate progress updates and tag/performer search
- add saved search API with persistence and tests
- support filtering the media library by minimum width and duration
- secure API endpoints with an optional API token
- serve a simple web library browser at `/ui/library`
- remove unused sha1 import flagged by linter

## Testing
- `pip install fastapi uvicorn pydantic httpx Pillow numpy`
- `ruff check app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4793759808330b500d35afe14fb21